### PR TITLE
refactor(cli): remove Show_Help mid-parse callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Clara.CLI` is now parse-only** (no parse-time callbacks).
+  Help and version are surfaced exclusively as outcome signals
+  on `Parse_Outcome.Result` (`Error_Value.Kind in
+  Help_Requested | Version_Requested`).  Consumers detect these
+  after `Parse` returns and render help / version text
+  themselves; parse-time control flow is decoupled from
+  consumer rendering.  Pure parse → outcome semantics simplify
+  consumer integration and remove a mid-parse side-effect
+  surprise.
+
 ### Deprecated
 
 ### Removed
+
+- **`Show_Help` generic formal procedure** removed from
+  `Clara.CLI`.  Previously, encountering `--help` or `-h`
+  during parse would invoke a consumer-supplied `Show_Help`
+  callback in addition to returning `Help_Requested`.  The
+  callback is no longer invoked; `Help_Requested` (and
+  `Version_Requested` for `--version`) are the sole signals.
+  **Migration**: drop `Show_Help => ...` from your
+  `Clara.CLI` instantiation; render help / version after
+  `Parse` returns by inspecting `Error_Value.Kind`.
 
 ### Fixed
 

--- a/src/clara-cli.adb
+++ b/src/clara-cli.adb
@@ -407,9 +407,11 @@ package body Clara.CLI is
                         then Rest (Equals_Pos + 1 .. Rest'Last)
                         else "");
                   begin
-                     --  Built-in: --help, --version
+                     --  Built-in: --help, --version.  Both surface as
+                     --  pure outcome signals; consumers render help /
+                     --  version after Parse returns.  No mid-parse
+                     --  callback (the Show_Help formal was removed).
                      if Name = "help" then
-                        Show_Help;
                         return Parse_Outcome.New_Error
                           (Help_Requested_Error);
                      elsif Name = "version" then
@@ -490,9 +492,10 @@ package body Clara.CLI is
                      declare
                         C : constant Character := Arg (I);
                      begin
-                        --  Built-in: -h
+                        --  Built-in: -h (matches the long --help
+                        --  built-in; pure outcome signal, no mid-parse
+                        --  callback).
                         if C = 'h' then
-                           Show_Help;
                            return Parse_Outcome.New_Error
                              (Help_Requested_Error);
                         end if;

--- a/src/clara-cli.ads
+++ b/src/clara-cli.ads
@@ -28,6 +28,15 @@ pragma Ada_2022;
 --    Config : constant CLI.CLI_Config := ( ... );
 --    Result : constant CLI.Parse_Outcome.Result := CLI.Parse (Config);
 --
+--  Help / version semantics:
+--    `--help` / `-h` produce `Parse_Outcome.New_Error` with kind
+--    `Help_Requested`; `--version` produces `Version_Requested`.
+--    Parse is side-effect-free with respect to user-supplied
+--    callbacks — consumers detect these outcomes after Parse
+--    returns and render help / version text themselves.  No
+--    Show_Help formal procedure: rendering is the consumer's
+--    responsibility, decoupled from parse-time control flow.
+--
 --  ===========================================================================
 
 with Clara.Types;  use Clara.Types;
@@ -40,10 +49,13 @@ generic
    type Flag_Id       is (<>);
    type Option_Id     is (<>);
    type Positional_Id is (<>);
-   App_Name        : String;  --  Used by consumer's Show_Help
-   App_Description : String;  --  Used by consumer's Show_Help
+   App_Name        : String;
+   App_Description : String;
    pragma Unreferenced (App_Name, App_Description);
-   with procedure Show_Help is null;
+   --  App_Name / App_Description are kept as generic formals so consumers
+   --  can document branding inside their own help renderers.  Clara itself
+   --  does not consume them (Show_Help was removed in favor of pure
+   --  outcome-driven help / version handling).
 package Clara.CLI is
 
    --  ==========================================================================

--- a/test/unit/test_cli.adb
+++ b/test/unit/test_cli.adb
@@ -31,21 +31,13 @@ package body Test_CLI is
    type Test_Opt is (Workers, Output, Config, Exclude);
    type Test_Pos is (Paths);
 
-   Help_Called : Boolean := False;
-
-   procedure Test_Help is
-   begin
-      Help_Called := True;
-   end Test_Help;
-
    package CLI is new Clara.CLI
      (Command_Id      => Test_Cmd,
       Flag_Id         => Test_Flag,
       Option_Id       => Test_Opt,
       Positional_Id   => Test_Pos,
       App_Name        => "testapp",
-      App_Description => "Test application",
-      Show_Help       => Test_Help);
+      App_Description => "Test application");
 
    Test_Config : constant CLI.CLI_Config :=
      (Commands =>
@@ -436,41 +428,33 @@ package body Test_CLI is
       end;
 
       --  ===== Help request (long) =====
+      --  Show_Help mid-parse callback was removed; help is now a pure
+      --  outcome signal via Help_Requested error kind.
       declare
          Args : constant CLI.Argument_Array := [1 => A ("--help")];
+         R : constant CLI.Parse_Outcome.Result :=
+           CLI.Parse (Test_Config, Args);
       begin
-         Help_Called := False;
-         declare
-            R : constant CLI.Parse_Outcome.Result :=
-              CLI.Parse (Test_Config, Args);
-         begin
-            Assert (not R.Is_Ok, "--help returns error");
-            if not R.Is_Ok then
-               Assert
-                 (R.Error_Value.Kind = Help_Requested,
-                  "--help: Help_Requested");
-            end if;
-            Assert (Help_Called, "--help calls Show_Help callback");
-         end;
+         Assert (not R.Is_Ok, "--help returns error");
+         if not R.Is_Ok then
+            Assert
+              (R.Error_Value.Kind = Help_Requested,
+               "--help: Help_Requested");
+         end if;
       end;
 
       --  ===== Help request (short) =====
       declare
          Args : constant CLI.Argument_Array := [1 => A ("-h")];
+         R : constant CLI.Parse_Outcome.Result :=
+           CLI.Parse (Test_Config, Args);
       begin
-         Help_Called := False;
-         declare
-            R : constant CLI.Parse_Outcome.Result :=
-              CLI.Parse (Test_Config, Args);
-         begin
-            Assert (not R.Is_Ok, "-h returns error");
-            if not R.Is_Ok then
-               Assert
-                 (R.Error_Value.Kind = Help_Requested,
-                  "-h: Help_Requested");
-            end if;
-            Assert (Help_Called, "-h calls Show_Help callback");
-         end;
+         Assert (not R.Is_Ok, "-h returns error");
+         if not R.Is_Ok then
+            Assert
+              (R.Error_Value.Kind = Help_Requested,
+               "-h: Help_Requested");
+         end if;
       end;
 
       --  ===== Version request =====
@@ -604,18 +588,14 @@ package body Test_CLI is
       --  ===== Is_Graceful_Exit predicate on parse errors =====
       declare
          Args : constant CLI.Argument_Array := [1 => A ("--help")];
+         R : constant CLI.Parse_Outcome.Result :=
+           CLI.Parse (Test_Config, Args);
       begin
-         Help_Called := False;
-         declare
-            R : constant CLI.Parse_Outcome.Result :=
-              CLI.Parse (Test_Config, Args);
-         begin
-            if not R.Is_Ok then
-               Assert
-                 (Is_Graceful_Exit (R.Error_Value),
-                  "Help error Is_Graceful_Exit");
-            end if;
-         end;
+         if not R.Is_Ok then
+            Assert
+              (Is_Graceful_Exit (R.Error_Value),
+               "Help error Is_Graceful_Exit");
+         end if;
       end;
 
       Total := Total_Count;


### PR DESCRIPTION
## Summary

Removes the `Show_Help` formal procedure from `Clara.CLI`'s generic signature.  Help and version are now sole outcome signals on `Parse_Outcome.Result.Error_Value.Kind` (`Help_Requested` / `Version_Requested`); consumers render text after `Parse` returns.

Pulls a parse-time side effect out of Clara so the parser is purely \"argv → outcome.\" Adafmt is the immediate motivation (slice 5.F.a CLI parser, in pre-phase as of 2026-05-01) — its CLI wrapper would otherwise have to pass `Show_Help => null` and ignore the dead callback. Removing the formal cleans up the API for any future consumer too.

### What changed

**Spec** (`src/clara-cli.ads`):
- Removed `with procedure Show_Help is null;` from the generic formal list.
- Updated docstring to document the pure-outcome help/version semantics.
- Kept `App_Name` / `App_Description` formals (still `pragma Unreferenced`; consumers may use them in their own help renderers).

**Body** (`src/clara-cli.adb`):
- Removed the two `Show_Help;` call sites (long `--help` / `-h` paths).
- `Parse_Outcome.New_Error (Help_Requested_Error)` is the sole exit; same for `Version_Requested_Error` (which never had a callback).

**Tests** (`test/unit/test_cli.adb`):
- Removed `Help_Called : Boolean` flag and `Test_Help` procedure.
- Removed `Show_Help => Test_Help` from the `Test_Config` instantiation.
- Removed all `Help_Called := False` resets and `Assert (Help_Called, ...)` assertions.
- Kept all `Assert (R.Error_Value.Kind = Help_Requested, ...)` assertions — those are the outcome-based checks that survive the refactor.

### Migration

Consumers drop `Show_Help => ...` from their `Clara.CLI` instantiation and render help/version after `Parse` returns by inspecting `Error_Value.Kind`. No change to the help/version *recognition* (Clara still recognizes `--help` / `-h` / `--version` implicitly without a Flag_Def declaration).

## Test plan

- [x] \`alr build\` — PASS
- [x] Unit tests — 124 PASS
- [x] Integration tests — 35 PASS

## Pre-release no-backcompat

Per `feedback_pre_release_no_backcompat.md` (carried forward across this ecosystem of pre-v1.0.0 projects), this is a clean breaking change rather than a deprecation. Adafmt — the sole consumer — bumps its clara path-pin to this commit immediately after merge.