### PR TITLE
docs(changelog): set [1.0.0] tag date to 2026-06-09 (T0 of v1.0.0 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 **Version:** 1.0.0<br>
-**Date:** 2025-12-29<br>
+**Date:** 2026-06-09<br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
-**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
+**Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>
 **Status:** Released
 
 All notable changes to this project will be documented in this file.
@@ -18,7 +18,7 @@ No unreleased changes yet.
 
 ---
 
-## [1.0.0] - <YYYY-MM-DD pending tag>
+## [1.0.0] - 2026-06-09
 
 **Test Coverage:** 79 unit + 0 integration + 0 examples = 79 total
 


### PR DESCRIPTION
## Summary

**Slice T0 of the clara v1.0.0 release sequence**
([adafmt#42](https://github.com/abitofhelp/adafmt/issues/42)).
Replaces the `<YYYY-MM-DD pending tag>` placeholder that PR #10
introduced with the intended tag-push date **2026-06-09**, sets the
top metadata `Date:` field to the same value, and updates the
Copyright year range to `© 2025-2026`.

Scope is deliberately **CHANGELOG.md only** — reversible docs work,
no release execution.

If the tag-push slips beyond 2026-06-09, the policy is to **patch
CHANGELOG before G6, not accept date drift**.

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `5a97739` | `docs(changelog): set [1.0.0] tag date to 2026-06-09 (T0 of v1.0.0 release)` | `CHANGELOG.md` (+3 / -3) |

Diff total: 1 file, +3 / -3.

## What the change does (mechanical only)

```diff
-**Date:** 2025-12-29<br>
+**Date:** 2026-06-09<br>

-**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
+**Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>

-## [1.0.0] - <YYYY-MM-DD pending tag>
+## [1.0.0] - 2026-06-09
```

No other files touched.

## Position in the v1.0.0 release sequence

This PR is **T0** in the approved Codex-reviewed release sequence:

1. **T0 — CHANGELOG tag-date prep (this PR)**
2. T1 — root `[[pins]] functional` removal from `alire.toml`
   (publish-ready tree; REQUIRED before G6)
3. Final pre-tag `xplatform-validation` on `main`
4. G6 — annotated `v1.0.0` tag push (hard stop: tag tree must have
   no root `[[pins]]`)
5. G9-dry — `alr publish --skip-submit` against tagged tree
6. G9 — `alr publish` to Alire community index
7. G7 — `gh release create v1.0.0 --verify-tag` with body that
   accurately describes Alire submission status

Each subsequent gate is owner-authorized + Codex-reviewed
independently.

## What this PR does NOT do

* No `alire.toml` edit — `[[pins]] functional` block stays for now;
  T1 removes it.
* No `test/alire.toml` edit — its test-side pin stays per Codex
  direction.
* No `src/version/clara-version.ads` edit — already 1 / 0 / 0.
* No README edit — `**Status:** Released` becomes accurate at G6.
* No `docs/formal/*.typ` edit — formal-doc baseline is a separate
  deferred decision item.
* No release-notes file — body for G7 will be drafted in a separate
  `exports/clara_v1_0_0_release_notes.md` after G9 submission status
  is known.
* No CI workflow edits.
* No source / test changes.
* No tag, no Release, no `alr publish`, no dependency unpinning.

## Validation

**Intentionally skipped** for this PR.

Rationale: T0 is CHANGELOG-only (+3 / -3) and cannot affect any
build behavior. The REQUIRED validation will run after T1 against
the publish-ready tree (with `[[pins]]` removed). T1's
`xplatform-validation` run, plus a final pre-tag run on the merged
`main`, are the gating signals before G6.

Prior validation evidence on the lineage:
- PR #10's adafmt xplatform-validation run
  [27051011555](https://github.com/abitofhelp/adafmt/actions/runs/27051011555)
  was green on both Linux cells at the immediate ancestor commit
  `8e2125e` (now squash-merged into `main` at `5b0d101`).

## clara main branch ruleset state

The branch push surfaced the same `Lock all branches` ruleset
(id `13699088`, target `branch`, enforcement `active`) that was
documented on PR #10. `bypass_actors` auto-bypassed the
`creation` rule on push — the remote logged
`Cannot create ref due to creations being restricted` then
immediately reported `[new branch]`. No content/diff problem.

**PR merge implication**: merge will require `gh pr merge --admin`
with an audit-trail body (mirroring PR #10's pattern, recording
the ruleset id and the validation lineage).

## Follow-ups deliberately deferred

* **T1 (next slice)** — root `[[pins]] functional` removal; REQUIRED
  before G6.
* **G6 tag-push** — gated on T1 merge + green pre-tag validation +
  Codex G6 review.
* **G9-dry / G9 / G7** — irreversible gates, each separately
  Codex-reviewed.
* **Formal-doc baseline** — `docs/formal/{srs,sds,stg}.typ` at
  `version: "0.1.0"` / `status: "Draft"`; separate owner-decision
  item.
* **clara + astengine ruleset governance review** — separate
  deferred decision item.
* **Date-slip handling** — if tag slips beyond 2026-06-09, file a
  small CHANGELOG-only patch before G6 to update both the `[1.0.0]`
  heading date and top metadata `Date:` field. **Date drift is not
  accepted.**

Refs: adafmt#42
