### PR TITLE
chore(alire): remove root functional path pin (T1 of v1.0.0 release)

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -16,6 +16,3 @@ tags = ["cli", "command-line", "arguments", "parser", "ada2022", "spark", "funct
 [[depends-on]]
 gnat = ">=13"
 functional = "^4.0.0"
-
-[[pins]]
-functional = { path = '../functional' }


### PR DESCRIPTION
## Summary

**Slice T1 of the clara v1.0.0 release sequence**
([adafmt#42](https://github.com/abitofhelp/adafmt/issues/42)).
Removes the root `[[pins]] functional = { path = '../functional' }`
block from `alire.toml` so that the v1.0.0 tag tree is publish-ready.
`clara` now resolves `functional = "^4.0.0"` to **`functional 4.1.1`**
from the Alire community index.

Scope is deliberately **`alire.toml` only** — reversible config change,
no version bump, no release execution.

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `3144709` | `chore(alire): remove root functional path pin (T1 — publish-ready tree before G6)` | `alire.toml` (+0 / -3) |

Diff total: 1 file, +0 / -3.

## What the change does (mechanical only)

```diff
 [[depends-on]]
 gnat = ">=13"
 functional = "^4.0.0"
-
-[[pins]]
-functional = { path = '../functional' }
```

`[[depends-on]] functional = "^4.0.0"` stays. The `[[pins]]` block is removed.

`test/alire.toml`'s test-side `[[pins]] clara = { path = ".." }` is **NOT** touched (test crate, not published; intentionally out of scope per the F-sequence plan).

## Why this works now (publishability path proven end-to-end)

The `[[pins]]` block was a local-development override that made clara unbuildable for any consumer without sibling-checkout layout. Removing it is only safe once `functional` is publicly consumable from the Alire community index. That precondition is now satisfied:

| F-sequence step | Result |
|---|---|
| F1 — functional `.gitmodules` SSH → HTTPS repair | merged (functional#6) |
| F2 — functional `4.1.0` → `4.1.1` version-prep | merged (functional#7) |
| F2-tag-prep / F2-tag-date / F2-tag — `v4.1.1` annotated tag pushed | tag object `ef950bf4d5a9da7bd26ccb95988751f6d2731841`, target `c1ff2600a58b24bf482ec1e44fb63c58c1b1e293` |
| F3 — `alr publish --skip-submit` dry-run | green; manifest MD5 `8ddbd0cade05ce973241b8c060d3fc1d` |
| F4 / D3-v4 — Alire community-index PR | [alire-project/alire-index#1951](https://github.com/alire-project/alire-index/pull/1951) **MERGED 2026-06-08T11:31:30Z** by maintainer `mosteo`, 21 / 21 CI checks SUCCESS |
| F5 — community-index visibility + consumer-by-version resolution | clean consumer with `[[depends-on]] functional = "^4.0.0"` (no pins) resolved to `functional 4.1.1`, deployed via HTTPS submodules, built successfully |

## Validation

### Dev-container sanity (T1 branch `3144709`)

| Step | Result |
|---|---|
| `alr index --update-all` | community index current (`functional-4.1.1.toml` present) |
| `alr update` | `+ functional 4.1.1 (new)` — pulled from index, NO path pin |
| `alr show --solve` dependency graph | `clara=1.0.0 → functional=4.1.1 (^4.0.0) → gnat=13.3.0 (gnat_external) (>=13)` |
| `alr build` | `Success: Build finished successfully in 0.47 seconds.` |
| `make test-unit` | **124 / 124 PASS** |

### adafmt xplatform-validation (run [`27177524751`](https://github.com/abitofhelp/adafmt/actions/runs/27177524751))

| Cell | Conclusion | Duration |
|---|---|---|
| `prepare-matrix` | ✅ success | 3 s |
| `linux-amd64` | ✅ success | ≈ 31 min 24 s (1 884 s) |
| `linux-arm64` | ✅ success | ≈ 21 min 35 s (1 295 s) |
| **Overall conclusion** | ✅ **`success`** | wall 01:15:12Z → 01:46:45Z |

Inputs: `adafmt_ref=main`, `clara_ref=release/v1-0-0-unpin-functional`, `astfmt_ref=main`, `astengine_ref=main`. The run confirms clara on the T1 branch builds clean as a sibling-pinned dependency of adafmt on both Linux architectures, with functional now resolved from the Alire community index rather than a local path.

## What this PR does NOT do

* No `test/alire.toml` edit — its `[[pins]] clara = { path = ".." }` stays (test crate, not published; intentionally out of scope).
* No version bump — clara stays at `1.0.0`.
* No `CHANGELOG.md` / README / formal-doc / source / test / CI / workflow changes.
* No tag, no GitHub Release, no `alr publish`.
* No ecosystem-wide unpinning (astengine / astfmt / adafmt all still pin functional locally).
* No clara T0 reversion — `<YYYY-MM-DD pending tag>` placeholder / Date / Copyright lines stay as set by PR #10.

## Position in the v1.0.0 release sequence

This PR is **T1** in the Codex-reviewed sequence:

1. T0 — CHANGELOG tag-date prep (merged in PR #10)
2. **T1 — root `[[pins]] functional` removal (this PR)**
3. G-validate — re-run xplatform-validation on the post-merge `main`
4. G6 — annotated `v1.0.0` tag push (hard stop: tag tree must have no root `[[pins]]`)
5. G9-dry — `alr publish --skip-submit` against tagged tree
6. G9 — `alr publish` submit to Alire community index
7. G7 — `gh release create v1.0.0 --verify-tag`

Each subsequent gate is owner-authorized + Codex-reviewed independently.

## clara main branch ruleset state

The branch push surfaced the `Lock all branches` ruleset (id `13699088`) auto-bypass on the `creation` rule, same pattern as PR #10 / #11. Merge will require `gh pr merge --admin` with an audit-trail body recording the ruleset id and the validation evidence.

## Follow-ups deliberately deferred

* **G-validate** — fresh xplatform-validation on merged `main` after this PR squashes.
* **G6** — annotated `v1.0.0` tag push, gated on G-validate green + Codex review.
* **G9-dry / G9 / G7** — separate gates, each Codex-reviewed before authorization.
* **Functional GitHub Release `v4.1.1`** — separate housekeeping gate on the functional repo.
* **Ecosystem-wide unpins** (astengine / astfmt / adafmt) — gated until clara v1.0.0 sequence proves the publishability path on a real consumer.

Refs: adafmt#42
