### PR TITLE
fix(gitmodules): switch submodule URLs from SSH to HTTPS for publishability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "scripts/python/shared"]
 	path = scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_scripts_python.git
+	url = https://github.com/abitofhelp/hybrid_scripts_python.git
 [submodule "test/scripts/python/shared"]
 	path = test/scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_test_python.git
+	url = https://github.com/abitofhelp/hybrid_test_python.git


### PR DESCRIPTION
## Summary

Restores HTTPS submodule URLs in `.gitmodules` so that `git clone --recursive` (used by `alr publish`'s "Deploy sources" step, and by any consumer that recursively clones clara) can fetch the dev/tooling submodules without SSH credentials.

Scope is deliberately **`.gitmodules` only** — reversible, two-URL rewrite, no release execution.

This is the **same publishability defect** that `functional` carried before [functional#6](https://github.com/abitofhelp/functional/pull/6) (shipped in `functional v4.1.1`, now LIVE on the Alire community index). It was discovered on clara during the G9-dry attempt for `v1.0.0`: `alr publish`'s step 2 of 5 ("Deploy sources") ran `git clone --recursive` which failed:

```
Host key verification failed.
fatal: clone of 'git@github.com:abitofhelp/hybrid_scripts_python.git' ... failed
fatal: clone of 'git@github.com:abitofhelp/hybrid_test_python.git' ... failed
```

The dev container (and any consumer environment without GitHub SSH host-key trust + SSH keys) cannot deploy clara at `v1.0.0` because of this. **`v1.0.0` was tagged but not submitted to Alire after dry-run publishability validation found SSH submodule URLs.** `v1.0.1` will be the first Alire-published release (separate follow-up PR).

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `63e4f4e` | `fix(gitmodules): switch submodule URLs from SSH to HTTPS for publishability` | `.gitmodules` (+2 / -2) |

Diff total: 1 file, +2 / -2.

## What the change does (mechanical only)

```diff
 [submodule "scripts/python/shared"]
 	path = scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_scripts_python.git
+	url = https://github.com/abitofhelp/hybrid_scripts_python.git
 [submodule "test/scripts/python/shared"]
 	path = test/scripts/python/shared
-	url = git@github.com:abitofhelp/hybrid_test_python.git
+	url = https://github.com/abitofhelp/hybrid_test_python.git
```

No path changes. No submodule gitlink / pointer changes
(verified: `scripts/python/shared` stays at `cf36a0f`,
`test/scripts/python/shared` stays at `8e0fae1`). No other files touched.

Locally, `git submodule sync` was run to update `.git/config`'s mirrored URLs so the working tree, `.gitmodules`, and `.git/config` agree on the host. (`.git/config` is not tracked; the sync is local-state housekeeping.)

## Why this matters

Both submodule repositories (`hybrid_scripts_python` and `hybrid_test_python`) are public on GitHub; HTTPS clones require no credentials. The previous SSH URLs caused failures in any consumer environment without SSH keys + a known_hosts entry for `github.com`, including the canonical Ada dev container and (almost certainly) GHA runners during `alr publish`.

## What about the v1.0.0 tag?

The public `v1.0.0` tag is preserved (`e3c24f4` → `8b6ea3b`, on origin). Per project rules (no destructive git operations without explicit owner authorization), the tag is **not** force-rewritten. After this PR merges, a separate version-bump PR will:

1. Bump version surfaces `1.0.0` → `1.0.1` (`alire.toml`, `test/alire.toml`, `src/version/clara-version.ads`)
2. Add a CHANGELOG `[1.0.1]` section noting this `.gitmodules` repair and explaining that `v1.0.0` was tagged but not submitted to Alire after dry-run publishability validation found SSH submodule URLs; `v1.0.1` is the first Alire-published release.
3. Tag-date prep → tag `v1.0.1` → `alr publish --skip-submit` dry-run → submit to alire-index.

This mirrors the exact path `functional` took (v4.1.0 tagged but unpublished → v4.1.1 published with the HTTPS fix).

## Validation (performed before PR open)

Clean recursive clone via HTTPS inside the dev container (`dev-container-ada-system-1`):

```bash
git clone --branch fix/gitmodules-https-for-publishability --recursive /workspace/clara /tmp/clara-fix-test
```

Result:
- `.gitmodules` in fresh clone shows HTTPS URLs ✅
- Both submodules cloned via HTTPS without credentials ✅
- `scripts/python/shared` → `cf36a0f38b407a3f3c65ea622c42ef6eeca3c795` (matches gitlink, unchanged)
- `test/scripts/python/shared` → `8e0fae1091a1dbb80f3b6627030a37cb0f303c64` (matches gitlink, unchanged)
- No SSH host-key prompts, no auth errors

## Position in the v1.0.0 / v1.0.1 release sequence

| Step | Status |
|---|---|
| T0 — CHANGELOG tag-date prep (PR #11) | merged |
| T1 — root `[[pins]] functional` removal (PR #12) | merged |
| G-validate — post-T1 xplatform-validation `27177524751` | green (linux-amd64 ✅, linux-arm64 ✅) |
| G6 — annotated `v1.0.0` tag | created and pushed ✅ |
| G9-dry — `alr publish --skip-submit` | ❌ FAILED at step 2/5 due to SSH `.gitmodules` |
| **F1-analog — `.gitmodules` SSH → HTTPS repair (this PR)** | **awaiting review** |
| F2-analog — version bump 1.0.0 → 1.0.1 + CHANGELOG `[1.0.1]` | next PR after this merges |
| F2-tag-prep + F2-tag — tag `v1.0.1` | gated downstream |
| G9-dry redux — `alr publish --skip-submit` against `v1.0.1` tree | gated downstream |
| G9 — submit to alire-index | gated, irreversible once PR opens |
| G7 — clara GitHub Release `v1.0.1` | gated; should reference Alire submission status accurately |

## What this PR does NOT do

* No `alire.toml` edit — version stays `1.0.0` on the working tree; the v1.0.1 bump is a separate PR.
* No `src/version/clara-version.ads` edit.
* No CHANGELOG edit.
* No README edit.
* No CI workflow edits.
* No source / test changes.
* No new tag — `v1.0.0` stays put; `v1.0.1` comes from a separate PR.
* No GitHub Release.
* No `alr publish` retry.
* No ecosystem-wide work (astengine / astfmt / adafmt unpins still gated; their own `.gitmodules` audit is a separate follow-up).

## clara main branch ruleset state

Expected: the `Lock all branches` ruleset (id `13699088`) will auto-bypass on `creation` at push, same pattern as PR #10 / #11 / #12. Merge will require `gh pr merge --admin` with an audit-trail body.

## Follow-ups deliberately deferred

* **v1.0.1 version bump + CHANGELOG `[1.0.1]` PR** — separate follow-up.
* **`v1.0.1` tag + Alire submission** — gated downstream.
* **`.gitmodules` audit on astengine / astfmt / adafmt** — owner-flagged for read-only/prep audit before any further tag work in those repos.
* **`v1.0.0` GitHub Release** — should NOT be created. The release history will start at `v1.0.1`.

Refs: adafmt#42
