### PR TITLE
chore(release): bump version 1.0.0 -> 1.0.1 (first Alire-published release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-**Version:** 1.0.0<br>
-**Date:** 2026-06-09<br>
+**Version:** 1.0.1<br>
+**Date:** <YYYY-MM-DD pending tag><br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
 **Copyright:** © 2025-2026 Michael Gardner, A Bit of Help, Inc.<br>
@@ -15,6 +15,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 No unreleased changes yet.
+
+---
+
+## [1.0.1] - <YYYY-MM-DD pending tag>
+
+**First Alire-published release of CLARA.**
+
+`v1.0.0` was tagged but not submitted to the Alire community index
+after `alr publish --skip-submit` dry-run validation found SSH
+submodule URLs in `.gitmodules` (`git@github.com:...`).  The dry-run
+publication failed at the "Deploy sources" step because the recursive
+clone could not fetch the public helper submodules
+(`hybrid_scripts_python`, `hybrid_test_python`) over SSH in
+credentials-free consumer environments such as the Alire dev container
+or GHA runners during `alr publish`.
+
+`v1.0.1` is the first version intended for Alire community-index
+submission.  No source / API / behavior changes vs `v1.0.0` — only
+the `.gitmodules` publishability repair (PR #13, merged `ec80afd`,
+2026-06-09) and the version-surface bump in this PR.  Mirrors the
+`functional` v4.1.0 → v4.1.1 pattern (functional#6 merged the
+HTTPS repair, functional `v4.1.1` was the first version published
+to the Alire community index, now LIVE).
+
+### Changed
+
+- Version bumped `1.0.0` → `1.0.1` across `alire.toml`,
+  `test/alire.toml`, `src/version/clara-version.ads`
+  (`Patch` and `Version` constants), and `test/unit/test_version.adb`
+  (`Patch = 1`, `Version = "1.0.1"`).
+
+### Not changed (vs `v1.0.0`)
+
+- No `src/` API or behavior changes.
+- Direct dependency stays at `functional = "^4.0.0"` (resolves to
+  `functional 4.1.1` from the Alire community index — no root
+  `[[pins]]` per T1 / PR #12).
+- No tag created by this PR; `v1.0.0` annotated tag preserved at
+  `e3c24f4` -> `8b6ea3b` (pre-`.gitmodules`-fix tree).
 
 ---
 

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "clara"
 description = "Type-safe CLI argument parsing with functional monads"
-version = "1.0.0"
+version = "1.0.1"
 
 authors = ["A Bit of Help, Inc. - Michael Gardner"]
 maintainers = ["A Bit of Help, Inc. - Michael Gardner <mjgardner@abitofhelp.com>"]

--- a/src/version/clara-version.ads
+++ b/src/version/clara-version.ads
@@ -33,7 +33,7 @@ is
    --  Semantic Version Components
    Major : constant Natural := 1;
    Minor : constant Natural := 0;
-   Patch : constant Natural := 0;
+   Patch : constant Natural := 1;
 
    --  Pre-release identifier (e.g., "dev", "alpha.1", "beta.2", "rc.1")
    --  Empty string for stable releases
@@ -44,7 +44,7 @@ is
    Build_Metadata : constant String := "";
 
    --  Full version string (e.g., "0.1.0-dev", "1.2.3", "2.0.0-rc.1+build.456")
-   Version : constant String := "1.0.0";
+   Version : constant String := "1.0.1";
 
    --  Check if this is a pre-release version
    function Is_Prerelease return Boolean is (Prerelease'Length > 0);

--- a/test/alire.toml
+++ b/test/alire.toml
@@ -1,6 +1,6 @@
 name = "clara_tests"
 description = "Test suite for clara"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Michael Gardner"]
 maintainers = ["Michael Gardner <mike@abitofhelp.com>"]
 licenses = "BSD-3-Clause"

--- a/test/unit/test_version.adb
+++ b/test/unit/test_version.adb
@@ -27,8 +27,8 @@ package body Test_Version is
 
       Assert (Clara.Version.Major = 1, "Major is 1");
       Assert (Clara.Version.Minor = 0, "Minor is 0");
-      Assert (Clara.Version.Patch = 0, "Patch is 0");
-      Assert (Clara.Version.Version = "1.0.0", "Version is 1.0.0");
+      Assert (Clara.Version.Patch = 1, "Patch is 1");
+      Assert (Clara.Version.Version = "1.0.1", "Version is 1.0.1");
       Assert
         (Clara.Version.Prerelease = "",
          "Prerelease is empty for stable");
@@ -38,7 +38,7 @@ package body Test_Version is
       Assert
         (not Clara.Version.Is_Development,
          "Is_Development is False for stable");
-      Assert (Clara.Version.Is_Stable, "Is_Stable is True for 1.0.0");
+      Assert (Clara.Version.Is_Stable, "Is_Stable is True for 1.0.1");
 
       Total := Total_Count;
       Passed := Passed_Count;


### PR DESCRIPTION
## Summary

**Slice F2-analog of the clara release sequence** — version-surface bump from `1.0.0` to `1.0.1` to prepare clara `v1.0.1` as the first version intended for Alire community-index submission.

This is a doc/config slice only. No `src/` API or behavior changes vs `v1.0.0`. Only the version surfaces flip across the 5 files listed below.

## Why `v1.0.1` and not a re-tag of `v1.0.0`?

`v1.0.0` was tagged (`e3c24f4` → `8b6ea3b`) but **not submitted** to the Alire community index after `alr publish --skip-submit` dry-run validation at G9-dry surfaced the SSH submodule URLs in `.gitmodules`:

```
fatal: clone of 'git@github.com:abitofhelp/hybrid_scripts_python.git' ... failed
fatal: clone of 'git@github.com:abitofhelp/hybrid_test_python.git' ... failed
```

The `.gitmodules` HTTPS publishability repair was merged separately as [#13](https://github.com/abitofhelp/clara/pull/13) (commit `ec80afd`, 2026-06-09); per project rules (no destructive git operations without explicit owner authorization), the `v1.0.0` annotated tag was **preserved at the pre-fix tree** rather than force-rewritten. `v1.0.1` is the first version with the HTTPS-repaired tree and will be the first version submitted to the Alire community index.

This mirrors the `functional` v4.1.0 → v4.1.1 pattern exactly: [functional#6](https://github.com/abitofhelp/functional/pull/6) merged the HTTPS repair; `functional v4.1.1` (not `v4.1.0`) was the first version published to the Alire community index, where it is now LIVE.

## Commit map

| # | SHA | Subject | Files |
|---|---|---|---|
| 1 | `1921fce` | `chore(release): bump version 1.0.0 -> 1.0.1 (first Alire-published release)` | 5 files (+48 / −9) |

Diff total: 5 files, +48 / −9.

## Version surfaces changed

```diff
- alire.toml:                      version = "1.0.0"
+ alire.toml:                      version = "1.0.1"

- test/alire.toml:                 version = "1.0.0"
+ test/alire.toml:                 version = "1.0.1"

- src/version/clara-version.ads:   Patch   : constant Natural := 0;
+ src/version/clara-version.ads:   Patch   : constant Natural := 1;

- src/version/clara-version.ads:   Version : constant String  := "1.0.0";
+ src/version/clara-version.ads:   Version : constant String  := "1.0.1";

- test/unit/test_version.adb:      Assert (Clara.Version.Patch = 0, "Patch is 0");
+ test/unit/test_version.adb:      Assert (Clara.Version.Patch = 1, "Patch is 1");

- test/unit/test_version.adb:      Assert (Clara.Version.Version = "1.0.0", "Version is 1.0.0");
+ test/unit/test_version.adb:      Assert (Clara.Version.Version = "1.0.1", "Version is 1.0.1");

- test/unit/test_version.adb:      Assert (Clara.Version.Is_Stable, "Is_Stable is True for 1.0.0");
+ test/unit/test_version.adb:      Assert (Clara.Version.Is_Stable, "Is_Stable is True for 1.0.1");
```

## CHANGELOG wording

**Top-of-file metadata** flips Version `1.0.0` → `1.0.1` and Date `2026-06-09` → `<YYYY-MM-DD pending tag>` (placeholder; will be set in a separate tag-date-prep step before the annotated `v1.0.1` tag, mirroring functional's F2-tag-prep / F2-tag-date pattern).

**New `[1.0.1]` section** added under `[Unreleased]`, before the historical `[1.0.0]` entry. Verbatim heading + opening:

```markdown
## [1.0.1] - <YYYY-MM-DD pending tag>

**First Alire-published release of CLARA.**

`v1.0.0` was tagged but not submitted to the Alire community index
after `alr publish --skip-submit` dry-run validation found SSH
submodule URLs in `.gitmodules` (`git@github.com:...`).  The dry-run
publication failed at the "Deploy sources" step because the recursive
clone could not fetch the public helper submodules
(`hybrid_scripts_python`, `hybrid_test_python`) over SSH in
credentials-free consumer environments such as the Alire dev container
or GHA runners during `alr publish`.

`v1.0.1` is the first version intended for Alire community-index
submission.  No source / API / behavior changes vs `v1.0.0` — only
the `.gitmodules` publishability repair (PR #13, merged `ec80afd`,
2026-06-09) and the version-surface bump in this PR.  Mirrors the
`functional` v4.1.0 → v4.1.1 pattern (functional#6 merged the
HTTPS repair, functional `v4.1.1` was the first version published
to the Alire community index, now LIVE).

### Changed

- Version bumped `1.0.0` → `1.0.1` across `alire.toml`,
  `test/alire.toml`, `src/version/clara-version.ads`
  (`Patch` and `Version` constants), and `test/unit/test_version.adb`
  (`Patch = 1`, `Version = "1.0.1"`).

### Not changed (vs `v1.0.0`)

- No `src/` API or behavior changes.
- Direct dependency stays at `functional = "^4.0.0"` (resolves to
  `functional 4.1.1` from the Alire community index — no root
  `[[pins]]` per T1 / PR #12).
- No tag created by this PR; `v1.0.0` annotated tag preserved at
  `e3c24f4` -> `8b6ea3b` (pre-`.gitmodules`-fix tree).
```

The historical `[1.0.0] - 2026-06-09` section is preserved verbatim below the new `[1.0.1]` section.

## Validation (performed before PR open, in `dev-container-ada-system-1`)

| Check | Result |
|---|---|
| `alr -n build -- -XGNATCOLL_ICONV_OPT=` on clara root | ✅ `Success: Build finished successfully in 0.38 seconds.` |
| `alr -n build -- -XGNATCOLL_ICONV_OPT=` on test crate | ✅ `Success: Build finished successfully in 2.28 seconds.` |
| `./bin/unit_runner` | ✅ **124 / 124 PASS** (same count as T1 / pre-bump baseline; version test `Test_Version` updated to assert `1.0.1` and passes) |
| No `[[pins]]` in root `alire.toml` | ✅ (preserved from T1 / PR #12 removal) |
| Direct dependency `functional = "^4.0.0"` unchanged | ✅ |
| `.gitmodules` URLs HTTPS for both public helper submodules | ✅ (preserved from PR #13 repair) |
| `v1.0.0` annotated tag intact (`e3c24f4` -> `8b6ea3b`) | ✅ NOT re-pointed |

## Position in the v1.0.1 release sequence

| Step | Status |
|---|---|
| T0 — CHANGELOG `[1.0.0]` tag-date prep (PR #11) | merged |
| T1 — root `[[pins]] functional` removal (PR #12) | merged |
| G-validate — post-T1 xplatform-validation `27177524751` | green ✅ |
| G6 — annotated `v1.0.0` tag pushed | done ✅ (`e3c24f4` -> `8b6ea3b`) |
| G9-dry — `alr publish --skip-submit` dry-run on `v1.0.0` tree | ❌ FAILED (SSH `.gitmodules`) |
| F1-analog — `.gitmodules` SSH → HTTPS repair (PR #13) | merged ✅ (`ec80afd`) |
| **F2-analog — version 1.0.0 → 1.0.1 (this PR)** | **awaiting review** |
| F2-tag-prep — set CHANGELOG `[1.0.1]` and top-of-file dates to the chosen tag date | next PR after this merges |
| F2-tag — annotated `v1.0.1` tag push | gated downstream |
| G9-dry redux — `alr publish --skip-submit` on `v1.0.1` tree | gated downstream |
| G9 — `alr publish` submit to alire-index | gated, irreversible once submitted |
| G7 — clara GitHub Release `v1.0.1` | gated; reference Alire submission status accurately |

## What this PR does NOT do

* No `src/` or production-code changes.
* No `.gitmodules` changes (the HTTPS repair landed in PR #13).
* No tag — `v1.0.0` stays put; `v1.0.1` comes from a separate F2-tag step.
* No GitHub Release.
* No `alr publish` run.
* No `corpus_ada` / astfmt / adafmt / astengine repo changes.
* No `functional` repo changes — the `functional 4.1.1` Alire crate is consumed as-is from the community index.

## clara main branch ruleset state

Expected: the `Lock all branches` ruleset (id `13699088`) will auto-bypass on `creation` at push, same pattern as PR #10 / #11 / #12 / #13. Merge will require `gh pr merge --admin` with an audit-trail body when authorized.

## Follow-ups deliberately deferred

* **F2-tag-prep PR** — set CHANGELOG `[1.0.1]` Date and top-of-file Date to the chosen tag date (`<YYYY-MM-DD>`).
* **F2-tag** — annotated `v1.0.1` tag push.
* **G9-dry redux** — `alr publish --skip-submit` against `v1.0.1` tree.
* **G9** — `alr publish` submit to the Alire community index. Irreversible.
* **G7** — `gh release create v1.0.1 --verify-tag`.

Refs: adafmt#42
